### PR TITLE
delSlice using binary search to found out idx&unit test

### DIFF
--- a/consistent.go
+++ b/consistent.go
@@ -244,10 +244,22 @@ func (c *Consistent) loadOK(host string) bool {
 }
 
 func (c *Consistent) delSlice(val uint64) {
-	for i := 0; i < len(c.sortedSet); i++ {
-		if c.sortedSet[i] == val {
-			c.sortedSet = append(c.sortedSet[:i], c.sortedSet[i+1:]...)
+	idx := -1
+	l := 0
+	r := len(c.sortedSet) - 1
+	for l <= r {
+		m := (l + r) / 2
+		if c.sortedSet[m] == val {
+			idx = m
+			break
+		} else if c.sortedSet[m] < val {
+			l = m + 1
+		} else if c.sortedSet[m] > val {
+			r = m - 1
 		}
+	}
+	if idx != -1 {
+		c.sortedSet = append(c.sortedSet[:idx], c.sortedSet[idx+1:]...)
 	}
 }
 

--- a/consistent_test.go
+++ b/consistent_test.go
@@ -116,3 +116,18 @@ func TestHosts(t *testing.T) {
 	fmt.Println("hosts in the ring", c.Hosts())
 
 }
+
+func TestDelSlice(t *testing.T) {
+	c := &Consistent{}
+	c.sortedSet = append(c.sortedSet, []uint64{0, 1, 2, 3, 5, 20, 22, 23, 25, 27, 28, 30, 35, 37, 1008, 1009}...)
+
+	fmt.Printf("%+v\n", c.sortedSet)
+
+	c.delSlice(25)
+	c.delSlice(37)
+	c.delSlice(1009)
+	c.delSlice(3)
+	c.delSlice(100000)
+
+	fmt.Printf("%+v\n", c.sortedSet)
+}

--- a/consistent_test.go
+++ b/consistent_test.go
@@ -118,16 +118,25 @@ func TestHosts(t *testing.T) {
 }
 
 func TestDelSlice(t *testing.T) {
+	items := []uint64{0, 1, 2, 3, 5, 20, 22, 23, 25, 27, 28, 30, 35, 37, 1008, 1009}
+	deletes := []uint64{25, 37, 1009, 3, 100000}
+
 	c := &Consistent{}
-	c.sortedSet = append(c.sortedSet, []uint64{0, 1, 2, 3, 5, 20, 22, 23, 25, 27, 28, 30, 35, 37, 1008, 1009}...)
+	c.sortedSet = append(c.sortedSet, items...)
 
-	fmt.Printf("%+v\n", c.sortedSet)
+	fmt.Printf("before deletion%+v\n", c.sortedSet)
 
-	c.delSlice(25)
-	c.delSlice(37)
-	c.delSlice(1009)
-	c.delSlice(3)
-	c.delSlice(100000)
+	for _, val := range deletes {
+		c.delSlice(val)
+	}
 
-	fmt.Printf("%+v\n", c.sortedSet)
+	for _, val := range deletes {
+		for _, item := range c.sortedSet {
+			if item == val {
+				t.Fatalf("%d wasn't deleted\n", val)
+			}
+		}
+	}
+
+	fmt.Printf("after deletions: %+v\n", c.sortedSet)
 }


### PR DESCRIPTION
This is a pull request about issue:  [delSlice could be optimized](https://github.com/lafikl/consistent/issues/8).

It could enhance the performance when the hash ring is large enough.Thanks!